### PR TITLE
Update rag_app.py to fix the FLAN-T5-XXL input issue

### DIFF
--- a/lab4/rag_app/rag_app.py
+++ b/lab4/rag_app/rag_app.py
@@ -25,7 +25,7 @@ KENDRA_INDEX_ID = os.environ.get('KENDRA_INDEX_ID')
 #     accepts = "application/json"
 
 #     def transform_input(self, prompt, model_kwargs):
-#         input_str = json.dumps({"text_inputs": prompt, {"temperature":0, "max_length":200}})
+#         input_str = json.dumps({"text_inputs": prompt, "temperature": 0, "max_length": 200})
 #         return input_str.encode('utf-8')
     
 #     def transform_output(self, output):


### PR DESCRIPTION
On line 28 we need to change there are extra brackets in the ContentHandler class that causes the SageMaker endpoint to throw an error about missing key